### PR TITLE
IO error while preview or export `valid` asset

### DIFF
--- a/AssetStudio/AssetsManager.cs
+++ b/AssetStudio/AssetsManager.cs
@@ -135,10 +135,9 @@ namespace AssetStudio
                     assetsFileList.Add(assetsFile);
                     assetsfileListHash.Add(assetsFile.upperFileName);
                 }
-                else
-                {
-                    resourceFileReaders.Add(assetsFile.upperFileName, assetsFile.reader);
-                }
+
+                resourceFileReaders.Add(assetsFile.upperFileName, assetsFile.reader);
+
             }
         }
 


### PR DESCRIPTION
https://github.com/Perfare/AssetStudio/issues/316#issue-385131568

Add an `assetsFile` into `resourceFileReaders` despite whether  it is valid resolve the bug.

But I'm not sure if it is acceptable.