### PR TITLE
Support for SerializedFile version 22

### DIFF
--- a/AssetStudio/ObjectInfo.cs
+++ b/AssetStudio/ObjectInfo.cs
@@ -7,7 +7,7 @@ namespace AssetStudio
 {
     public class ObjectInfo
     {
-        public uint byteStart;
+        public long byteStart;
         public uint byteSize;
         public int typeID;
         public int classID;

--- a/AssetStudio/ObjectReader.cs
+++ b/AssetStudio/ObjectReader.cs
@@ -10,7 +10,7 @@ namespace AssetStudio
     {
         public SerializedFile assetsFile;
         public long m_PathID;
-        public uint byteStart;
+        public long byteStart;
         public uint byteSize;
         public ClassIDType type;
         public SerializedType serializedType;

--- a/AssetStudio/SerializedFile.cs
+++ b/AssetStudio/SerializedFile.cs
@@ -55,6 +55,14 @@ namespace AssetStudio
                 m_FileEndianess = (EndianType)reader.ReadByte();
             }
 
+            if (header.m_Version >= 22)
+            {
+                header.m_MetadataSize = reader.ReadUInt32();
+                header.m_FileSize = reader.ReadInt64();
+                header.m_DataOffset = reader.ReadInt64();
+                reader.ReadInt64(); // unknown
+            }
+
             //ReadMetadata
             if (m_FileEndianess == EndianType.LittleEndian)
             {
@@ -106,7 +114,12 @@ namespace AssetStudio
                     reader.AlignStream();
                     objectInfo.m_PathID = reader.ReadInt64();
                 }
-                objectInfo.byteStart = reader.ReadUInt32();
+
+                if (header.m_Version >= 22)
+                    objectInfo.byteStart = reader.ReadInt64();
+                else
+                    objectInfo.byteStart = reader.ReadUInt32();
+
                 objectInfo.byteStart += header.m_DataOffset;
                 objectInfo.byteSize = reader.ReadUInt32();
                 objectInfo.typeID = reader.ReadInt32();

--- a/AssetStudio/SerializedFileHeader.cs
+++ b/AssetStudio/SerializedFileHeader.cs
@@ -8,9 +8,9 @@ namespace AssetStudio
     public class SerializedFileHeader
     {
         public uint m_MetadataSize;
-        public uint m_FileSize;
+        public long m_FileSize;
         public uint m_Version;
-        public uint m_DataOffset;
+        public long m_DataOffset;
         public byte m_Endianess;
         public byte[] m_Reserved;
     }


### PR DESCRIPTION
Unity 2020.1.0a19 introduced version 22 of the serialized file format, which now stores offsets in 64-bit. This PR adds support for those changes.