### PR TITLE
Fix model extraction with correct size

### DIFF
--- a/AssetStudioFBX/AssetStudioFBXExporter.cpp
+++ b/AssetStudioFBX/AssetStudioFBXExporter.cpp
@@ -55,7 +55,7 @@ namespace AssetStudio
 		IOS_REF.SetBoolProp(EXP_FBX_GLOBAL_SETTINGS, true);
 
 		FbxGlobalSettings& globalSettings = pScene->GetGlobalSettings();
-		globalSettings.SetSystemUnit(FbxSystemUnit(scaleFactor));
+		globalSettings.SetSystemUnit(FbxSystemUnit(scaleFactor, scaleFactor));
 
 		if (imported->AnimationList->Count > 0)
 		{


### PR DESCRIPTION
Before the fix, each model were extracted scaled with **ScaleFactor** (set on _Export Options -> Fbx -> ScaleFactor_).
This method is not good since mess with Physics and Animations when imported to Unity or other 3D software.
After the fix, the models are exported scaled to 1 but with the ScaleFactor applied correctly. 