### PR TITLE
fix null pointer exception exporting objects without UV maps

### DIFF
--- a/AssetStudioFBX/AssetStudioFBXExporter.cpp
+++ b/AssetStudioFBX/AssetStudioFBXExporter.cpp
@@ -543,7 +543,9 @@ namespace AssetStudio
 						{
 							auto m_UV = iVertex->UV[uv];
 							auto lGeometryElementUV = pMesh->GetElementUV(uv);
-							lGeometryElementUV->GetDirectArray().Add(FbxVector2(m_UV[0], m_UV[1]));
+							if (lGeometryElementUV != NULL) {
+								lGeometryElementUV->GetDirectArray().Add(FbxVector2(m_UV[0], m_UV[1]));
+							}
 						}
 					}
 


### PR DESCRIPTION
This fixes a crash I experienced when trying to export a large bundle.. I think it was happening because some objects didn't have UV maps..

I see a few lines above at some point the number of UV maps it tries to export was reduced from 8 to 2, and I wonder if this was someone trying to work around a similar problem.. I left this at 2, and checkeding for the null pointer allowed me to export the assets without crashes.