### PR TITLE
Material and AnimatorController fix

### DIFF
--- a/AssetStudio/Classes/AnimatorController.cs
+++ b/AssetStudio/Classes/AnimatorController.cs
@@ -279,7 +279,7 @@ namespace AssetStudio
             }
 
             m_ClipID = reader.ReadUInt32();
-            if (version[0] == 4 && version[1] >= 5) //4.5 - 5.0
+            if ((version[0] == 4 && version[1] >= 5) || (version[0] == 5 && version[1] == 0))//4.5 - 5.0
             {
                 m_ClipIndex = reader.ReadUInt32();
             }

--- a/AssetStudio/Classes/Material.cs
+++ b/AssetStudio/Classes/Material.cs
@@ -56,16 +56,18 @@ namespace AssetStudio
         {
             m_Shader = new PPtr<Shader>(reader);
 
-            if (version[0] == 4 && version[1] >= 1) //4.x
-            {
-                var m_ShaderKeywords = reader.ReadStringArray();
-            }
-
             if (version[0] >= 5) //5.0 and up
             {
                 var m_ShaderKeywords = reader.ReadAlignedString();
                 var m_LightmapFlags = reader.ReadUInt32();
             }
+
+            else if (version[0] == 4 && version[1] >= 1) //4.x
+            {
+                var m_ShaderKeywords = reader.ReadStringArray();
+            }
+
+
 
             if (version[0] > 5 || (version[0] == 5 && version[1] >= 6)) //5.6 and up
             {


### PR DESCRIPTION
Hello,
a user (edcrfv#2933) of my Python port of AssetStudio reported an issue regarding the Material and AnimationController classes.
The specific objects of said classes couldn't be loaded in either, port nor original.

This PR fixes the issue that caused this problem.


The file that caused the problem is:
 [pm0001_00_00_prefab.unity3d](https://cdn.discordapp.com/attachments/603363030536814602/746627368080244777/pm0001_00_00_prefab.unity3d)