### PR TITLE
Problems in exporting fbx with multiple blendshapes

### DIFF
--- a/AssetStudioFBXNative/api.cpp
+++ b/AssetStudioFBXNative/api.cpp
@@ -1093,7 +1093,7 @@ AS_API(void) AsFbxMorphAddBlendShapeChannel(AsFbxContext* pContext, AsFbxMorphCo
 	}
 }
 
-AS_API(void) AsFbxMorphAddBlendShapeChannelShape(AsFbxContext* pContext, AsFbxMorphContext* pMorphContext, float weight)
+AS_API(void) AsFbxMorphAddBlendShapeChannelShape(AsFbxContext* pContext, AsFbxMorphContext* pMorphContext, float weight, const char* shapeName)
 {
 	if (pContext == nullptr || pContext->pScene == nullptr)
 	{
@@ -1105,7 +1105,7 @@ AS_API(void) AsFbxMorphAddBlendShapeChannelShape(AsFbxContext* pContext, AsFbxMo
 		return;
 	}
 
-	auto lShape = FbxShape::Create(pContext->pScene, FbxString(weight));
+	auto lShape = FbxShape::Create(pContext->pScene, shapeName);
 	pMorphContext->lShape = lShape;
 
 	if (pMorphContext->lBlendShapeChannel != nullptr) {
@@ -1126,12 +1126,9 @@ AS_API(void) AsFbxMorphCopyBlendShapeControlPoints(AsFbxMorphContext* pMorphCont
 
 	pMorphContext->lShape->InitControlPoints(vectorCount);
 
-	auto dstControlPoints = pMorphContext->lShape->GetControlPoints();
-
 	for (int j = 0; j < vectorCount; j++)
 	{
-		auto vertex = srcControlPoints[j];
-		dstControlPoints[j] = FbxVector4(vertex);
+		pMorphContext->lShape->SetControlPointAt(FbxVector4(srcControlPoints[j]), j);;
 	}
 }
 
@@ -1142,7 +1139,25 @@ AS_API(void) AsFbxMorphSetBlendShapeVertex(AsFbxMorphContext* pMorphContext, uin
 		return;
 	}
 
-	auto pControlPoints = pMorphContext->lShape->GetControlPoints();
+	pMorphContext->lShape->SetControlPointAt(FbxVector4(x, y, z, 0), index);
+}
 
-	pControlPoints[index] = FbxVector4(x, y, z, 0);
+AS_API(void) AsFbxMorphCopyBlendShapeControlPointsNormal(AsFbxMorphContext* pMorphContext)
+{
+	if (pMorphContext == nullptr || pMorphContext->pMesh == nullptr || pMorphContext->lShape == nullptr)
+	{
+		return;
+	}
+
+	pMorphContext->lShape->InitNormals(pMorphContext->pMesh);
+}
+
+AS_API(void) AsFbxMorphSetBlendShapeVertexNormal(AsFbxMorphContext* pMorphContext, uint32_t index, float x, float y, float z)
+{
+	if (pMorphContext == nullptr || pMorphContext->lShape == nullptr)
+	{
+		return;
+	}
+
+	pMorphContext->lShape->SetControlPointNormalAt(FbxVector4(x, y, z, 0), index);
 }

--- a/AssetStudioFBXNative/api.h
+++ b/AssetStudioFBXNative/api.h
@@ -150,8 +150,12 @@ AS_API(void) AsFbxMorphDisposeContext(AsFbxMorphContext** ppMorphContext);
 
 AS_API(void) AsFbxMorphAddBlendShapeChannel(AsFbxContext* pContext, AsFbxMorphContext* pMorphContext, const char* channelName);
 
-AS_API(void) AsFbxMorphAddBlendShapeChannelShape(AsFbxContext* pContext, AsFbxMorphContext* pMorphContext, float weight);
+AS_API(void) AsFbxMorphAddBlendShapeChannelShape(AsFbxContext* pContext, AsFbxMorphContext* pMorphContext, float weight, const char* shapeName);
 
 AS_API(void) AsFbxMorphCopyBlendShapeControlPoints(AsFbxMorphContext* pMorphContext);
 
 AS_API(void) AsFbxMorphSetBlendShapeVertex(AsFbxMorphContext* pMorphContext, uint32_t index, float x, float y, float z);
+
+AS_API(void) AsFbxMorphCopyBlendShapeControlPointsNormal(AsFbxMorphContext* pMorphContext);
+
+AS_API(void) AsFbxMorphSetBlendShapeVertexNormal(AsFbxMorphContext* pMorphContext, uint32_t index, float x, float y, float z);

--- a/AssetStudioFBXWrapper/FbxExporterContext.PInvoke.cs
+++ b/AssetStudioFBXWrapper/FbxExporterContext.PInvoke.cs
@@ -298,14 +298,28 @@ namespace AssetStudio.FbxInterop
         [DllImport(FbxDll.DllName, CallingConvention = CallingConvention.Winapi)]
         private static extern void AsFbxMorphAddBlendShapeChannel(IntPtr pContext, IntPtr pMorphContext, IntPtr strChannelName);
 
+        private static void AsFbxMorphAddBlendShapeChannelShape(IntPtr pContext, IntPtr pMorphContext, float weight, string shapeName)
+        {
+            using (var shapeNameUtf8 = new Utf8StringHandle(shapeName))
+            {
+                AsFbxMorphAddBlendShapeChannelShape(pContext, pMorphContext, weight, shapeNameUtf8.DangerousGetHandle());
+            }
+        }
+
         [DllImport(FbxDll.DllName, CallingConvention = CallingConvention.Winapi)]
-        private static extern void AsFbxMorphAddBlendShapeChannelShape(IntPtr pContext, IntPtr pMorphContext, float weight);
+        private static extern void AsFbxMorphAddBlendShapeChannelShape(IntPtr pContext, IntPtr pMorphContext, float weight, IntPtr strShapeName);
 
         [DllImport(FbxDll.DllName, CallingConvention = CallingConvention.Winapi)]
         private static extern void AsFbxMorphCopyBlendShapeControlPoints(IntPtr pMorphContext);
 
         [DllImport(FbxDll.DllName, CallingConvention = CallingConvention.Winapi)]
         private static extern void AsFbxMorphSetBlendShapeVertex(IntPtr pMorphContext, uint index, float x, float y, float z);
+
+        [DllImport(FbxDll.DllName, CallingConvention = CallingConvention.Winapi)]
+        private static extern void AsFbxMorphCopyBlendShapeControlPointsNormal(IntPtr pMorphContext);
+
+        [DllImport(FbxDll.DllName, CallingConvention = CallingConvention.Winapi)]
+        private static extern void AsFbxMorphSetBlendShapeVertexNormal(IntPtr pMorphContext, uint index, float x, float y, float z);
 
     }
 }

--- a/AssetStudioFBXWrapper/FbxExporterContext.cs
+++ b/AssetStudioFBXWrapper/FbxExporterContext.cs
@@ -611,9 +611,11 @@ namespace AssetStudio.FbxInterop
                     {
                         AsFbxMorphAddBlendShapeChannel(_pContext, pMorphContext, channel.Name);
 
-                        foreach (var keyframe in channel.KeyframeList)
+                        for (var i = 0; i < channel.KeyframeList.Count; i++)
                         {
-                            AsFbxMorphAddBlendShapeChannelShape(_pContext, pMorphContext, keyframe.Weight);
+                            var keyframe = channel.KeyframeList[i];
+
+                            AsFbxMorphAddBlendShapeChannelShape(_pContext, pMorphContext, keyframe.Weight, i == 0 ? channel.Name : $"{channel.Name}_{i + 1}");
 
                             AsFbxMorphCopyBlendShapeControlPoints(pMorphContext);
 
@@ -621,6 +623,17 @@ namespace AssetStudio.FbxInterop
                             {
                                 var v = vertex.Vertex.Vertex;
                                 AsFbxMorphSetBlendShapeVertex(pMorphContext, vertex.Index, v.X, v.Y, v.Z);
+                            }
+
+                            if (keyframe.hasNormals)
+                            {
+                                AsFbxMorphCopyBlendShapeControlPointsNormal(pMorphContext);
+
+                                foreach (var vertex in keyframe.VertexList)
+                                {
+                                    var v = vertex.Vertex.Normal;
+                                    AsFbxMorphSetBlendShapeVertexNormal(pMorphContext, vertex.Index, v.X, v.Y, v.Z);
+                                }
                             }
                         }
                     }

--- a/AssetStudioUtility/ModelConverter.cs
+++ b/AssetStudioUtility/ModelConverter.cs
@@ -500,7 +500,7 @@ namespace AssetStudio
                         crc.Update(bytes, 0, (uint)bytes.Length);
                         morphChannelNames[crc.GetDigest()] = blendShapeName;
 
-                        channel.Name = shapeChannel.name;
+                        channel.Name = shapeChannel.name.Split('.').Last();
                         channel.KeyframeList = new List<ImportedMorphKeyframe>(shapeChannel.frameCount);
                         var frameEnd = shapeChannel.frameIndex + shapeChannel.frameCount;
                         for (int frameIdx = shapeChannel.frameIndex; frameIdx < frameEnd; frameIdx++)


### PR DESCRIPTION
Current fbx exporting process generates incorrect / corrupted BlendShape properties, because of the multiple blendshapes with the same name (, which is `FbxString(weight)` in `AsFbxMorphAddBlendShapeChannelShape`).

I think these names should be `channel.Name.split('.').Last()`, based on behaviour in AssetStudio 0.12.x.